### PR TITLE
fix: format dates in graphql query

### DIFF
--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -8,14 +8,13 @@ const Event = ({
     location,
     url
 }) => {
-    const newDate = new Date(date).toLocaleString('en-us', { month: 'long', day: '2-digit', year: 'numeric'})
     return (
         <Link to={url}>
             <li className="icon solid fa-bullhorn">
                 <h4>{event}</h4>
                 <p>{title}</p>
                 <p>{location}</p>
-                <p>{newDate}</p>
+                <p>{date}</p>
             </li>
         </Link>
     )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -187,7 +187,7 @@ export const eventQuery = graphql`
           frontmatter {
             title
             path
-            date
+            date(formatString: "MMMM DD, YYYY")
             videoUrl
             event
             location


### PR DESCRIPTION
There is an issue with dates displaying off by 1 day by reformatting in the component. This PR does the formatting as part of the graphql query